### PR TITLE
Initial pass at Windows support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,11 @@ FROM iron/base:latest
 # is /app.
 WORKDIR /app/
 
-COPY job-templates/job.yaml /app/
+COPY job-templates/ /app/
 
 # Add the binary from our builder stage to the image and set the default CMD
 COPY --from=builder /workspace/src/github.com/embarkstudios/kubekite/kubekite /app/
 RUN chmod +x /app/kubekite
 
-CMD ["/app/kubekite"]
+#CMD ["/app/kubekite", "--job-mapping", "job-mapping.yaml"] # TODO: Use this when we support windows
+CMD ["/app/kubekite", "--job-template", "job-linux.yaml"]

--- a/job-templates/job-linux.yaml
+++ b/job-templates/job-linux.yaml
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: buildkite-agent
+  name: buildkite-agent-linux
   namespace: buildkite
 spec:
   template:
@@ -29,23 +29,11 @@ spec:
           - name: BUILDKITE_BUILD_PATH
             value: /var/buildkite/builds
           - name: BUILDKITE_AGENT_TAGS
-            value: "queue=kubekite"
+            value: "queue=kubekite,os=linux"
           - name: BUILDKITE_AGENT_DEBUG
             value: "true"
           - name: BUILDKITE_GIT_CLEAN_FLAGS
             value: "-fdqx"
-          # - name: BUILDKITE_PLUGIN_S3_SECRETS_BUCKET
-          #   value: "your-secrets-bucket"
-          # - name: AWS_ACCESS_KEY_ID
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: aws-secrets
-          #       key: AWS_ACCESS_KEY_ID
-          # - name: AWS_SECRET_ACCESS_KEY
-          #   valueFrom:
-          #     secretKeyRef:
-          #       name: aws-secrets
-          #       key: AWS_SECRET_ACCESS_KEY
         volumeMounts:
           - name: buildkite-builds
             mountPath: /var/buildkite/builds

--- a/job-templates/job-mapping.yaml
+++ b/job-templates/job-mapping.yaml
@@ -1,0 +1,6 @@
+- template: job-linux.yaml
+  filters:
+  - "os=linux"
+- template: job-windows.yaml
+  filters:
+  - "os=windows"

--- a/job-templates/job-windows.yaml
+++ b/job-templates/job-windows.yaml
@@ -1,0 +1,69 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: buildkite-agent-windows
+  namespace: buildkite
+spec:
+  template:
+    metadata:
+      labels:
+        application: buildkite-agent
+    spec:
+      nodeSelector:
+        cloud.google.com/gke-local-ssd: "true"
+      restartPolicy: OnFailure
+      terminationGracePeriodSeconds: 1800
+      containers:
+      - name: buildkite-agent
+        image: # TODO: Use Windows image buildkite/agent:3.7.0
+        args: ["start", "--disconnect-after-job", "--disconnect-after-job-timeout", "300"]
+        imagePullPolicy: IfNotPresent
+        securityContext:
+          privileged: true
+        envFrom:
+          - secretRef:
+              name: buildkite-secrets
+        env:
+          - name: TERM
+            value: dumb
+          - name: BUILDKITE_BUILD_PATH
+            value: /var/buildkite/builds
+          - name: BUILDKITE_AGENT_TAGS
+            value: "queue=kubekite,os=windows"
+          - name: BUILDKITE_AGENT_DEBUG
+            value: "true"
+          - name: BUILDKITE_GIT_CLEAN_FLAGS
+            value: "-fdqx"
+        # TODO: Mount Windows things to Windows places
+        # volumeMounts:
+        #   - name: buildkite-builds
+        #     mountPath: /var/buildkite/builds
+        #   - name: ssh-keys
+        #     mountPath: /root/.ssh/id_rsa
+        #     subPath: id_rsa
+        #   - name: docker-binary
+        #     mountPath: /usr/bin/docker
+        #   - name: docker-socket
+        #     mountPath: /var/run/docker.sock
+        resources:
+          requests:
+            cpu: 2
+            memory: 1Gi
+          limits:
+            cpu: 4
+            memory: 4Gi
+      # volumes:
+      #   # A locally mounted SSD that we have 1 of in certain node pools
+      #   - name: buildkite-builds
+      #     hostPath:
+      #       path: /var/buildkite/builds
+      #   - name: ssh-keys
+      #     secret:
+      #       secretName: buildkite-agent-ssh
+      #       defaultMode: 0400
+      #   - name: docker-binary
+      #     hostPath:
+      #       path: /usr/bin/docker
+      #   - name: docker-socket
+      #     hostPath:
+      #       path: /var/run/docker.sock


### PR DESCRIPTION
This just allows us to specify different job templates based on the agent tags/filters specified on the buildkite steps instead of the 1:1 mapping in the original, to see how adding Windows might work.